### PR TITLE
add BSP_USING_DMA conditional for EDMA drivers in MIMXRT1180

### DIFF
--- a/MIMXRT1180/SConscript
+++ b/MIMXRT1180/SConscript
@@ -23,6 +23,11 @@ src = Split('''
             MIMXRT1189/drivers/fsl_lpuart.c
             ''')
 
+if GetDepend(['BSP_USING_DMA']):
+    src += ['MIMXRT1189/drivers/fsl_edma.c']
+    src += ['MIMXRT1189/drivers/fsl_edma_soc.c']
+    src += ['MIMXRT1189/drivers/fsl_lpuart_edma.c']
+
 if GetDepend(['SOC_MIMXRT1189CVM8C_CM33']):
     path += [cwd + '/MIMXRT1189/drivers/cm33']
     src += ['MIMXRT1189/system_MIMXRT1189_cm33.c']


### PR DESCRIPTION
add BSP_USING_DMA conditional for EDMA drivers in MIMXRT1180, for RT-Thread PR11489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled DMA (Direct Memory Access) support for LPUART communications and additional DMA operations on MIMXRT1180 platform when DMA is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->