### PR TITLE
add BSP_USING_FLEXSPI conditional for flexspi drivers in MIMXRT1180

### DIFF
--- a/MIMXRT1180/SConscript
+++ b/MIMXRT1180/SConscript
@@ -54,8 +54,8 @@ if GetDepend(['SOC_MIMXRT1189CVM8C_CM7']):
 # if GetDepend(['RT_USING_CAN']):
 #     src += ['MIMXRT1189/drivers/fsl_flexcan.c']
 
-# if GetDepend(['BSP_USING_FLEXSPI']):
-#     src += ['MIMXRT1189/drivers/fsl_flexspi.c']
+if GetDepend(['BSP_USING_FLEXSPI']):
+    src += ['MIMXRT1189/drivers/fsl_flexspi.c']
 
 #fsl os abstract files
 # src += ['MIMXRT1189/drivers/fsl_os_abstraction_rtthread.c']


### PR DESCRIPTION
add BSP_USING_FLEXSPI conditional for flexspi drivers in MIMXRT1180, for RT-Thread [PR #11486](https://github.com/RT-Thread/rt-thread/pull/11486)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled FlexSPI driver support in the build configuration when conditionally enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->